### PR TITLE
Fix config path comma bug

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -59,8 +59,8 @@ collections:
           widget: hidden,
           default: BlogPost,
         }
-      - name: path, 
-        label: Path, 
+      - name: path 
+        label: Path
         widget: string
         pattern: [/]
         hint: "Path must start with /"


### PR DESCRIPTION
The extra comma is causing new markdown files to use an invalid key `'path:'` instead of `path:`.  It is breaking the builds on netlify.

![Messages Image(3901228268)](https://user-images.githubusercontent.com/749118/81231163-b4523280-8fc0-11ea-8992-37875f9ef577.jpeg)
